### PR TITLE
GNOME runtime 41, FEDC support

### DIFF
--- a/dev.geopjr.Hashbrown.yaml
+++ b/dev.geopjr.Hashbrown.yaml
@@ -1,6 +1,6 @@
 app-id: dev.geopjr.Hashbrown
 runtime: org.gnome.Platform
-runtime-version: "41"
+runtime-version: '41'
 sdk: org.gnome.Sdk
 command: hashbrown
 finish-args:
@@ -13,8 +13,8 @@ cleanup:
   - /lib/pkgconfig
   - /share/doc
   - /share/man
-  - "*.a"
-  - "*.la"
+  - '*.a'
+  - '*.la'
 
 modules:
   - name: livevent
@@ -38,6 +38,9 @@ modules:
         url: https://github.com/GeopJr/Hashbrown.git
         tag: v1.3.4
         commit: c399c2c96b94667c239c8c73446329e1a68d2123
+        x-checker-data:
+          type: git
+          tag-pattern: ^v([\d.]+)$
       - type: archive
         dest: crystal/
         url: https://github.com/crystal-lang/crystal/releases/download/1.1.1/crystal-1.1.1-1-linux-x86_64.tar.gz

--- a/dev.geopjr.Hashbrown.yaml
+++ b/dev.geopjr.Hashbrown.yaml
@@ -1,6 +1,6 @@
 app-id: dev.geopjr.Hashbrown
 runtime: org.gnome.Platform
-runtime-version: "40"
+runtime-version: "41"
 sdk: org.gnome.Sdk
 command: hashbrown
 finish-args:


### PR DESCRIPTION
Updated GNOME runtime to 41, added FEDC support.