### PR TITLE
feat: v2.0.0

### DIFF
--- a/dev.geopjr.Hashbrown.yaml
+++ b/dev.geopjr.Hashbrown.yaml
@@ -55,7 +55,7 @@ modules:
     sources:
       - type: git
         url: https://gitlab.gnome.org/GNOME/libadwaita.git
-        tag: 1.0.0.alpha.3
+        tag: 1.0.0.alpha.4
   # Hashbrown
   - name: hashbrown
     buildsystem: simple
@@ -70,7 +70,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/GeopJr/Hashbrown.git
-        branch: v2.0.0-dev # TEMP: only during this PR is a draft
+        tag: 2.0.0
+        commit: 71ad29b98c09369d07dc21b5bd664eb2e8d4b2b5
         x-checker-data:
           type: git
           tag-pattern: ^v([\d.]+)$
@@ -80,7 +81,7 @@ modules:
         sha256: 66e51bd2e72363858b5a41755396158d6aaf76b177a51741e4ab2df3323f0ff4
       - type: git
         url: https://github.com/GeopJr/libadwaita.cr.git
-        commit: 672c5d7a31eb3e59439b9d2c98673d5f7b8d1314
+        commit: 75bb4affac8350698eaba9fe39d6936e3cff8d7e
         dest: lib/libadwaita
       - type: git
         url: https://github.com/elorest/compiled_license.git

--- a/dev.geopjr.Hashbrown.yaml
+++ b/dev.geopjr.Hashbrown.yaml
@@ -1,28 +1,62 @@
 app-id: dev.geopjr.Hashbrown
 runtime: org.gnome.Platform
-runtime-version: '41'
+runtime-version: "41"
 sdk: org.gnome.Sdk
 command: hashbrown
 finish-args:
   - --socket=wayland
   - --socket=fallback-x11
   - --share=ipc
+  - --device=dri
 
 cleanup:
   - /include
   - /lib/pkgconfig
   - /share/doc
   - /share/man
-  - '*.a'
-  - '*.la'
+  - "*.a"
+  - "*.la"
 
 modules:
+  # Required by Crystal
   - name: livevent
     sources:
       - type: git
         url: https://github.com/libevent/libevent.git
         tag: release-2.1.12-stable
-
+  # Required by Crystal for yaml parsing (/translations during compile-time)
+  - name: libyaml
+    sources:
+      - type: archive
+        url: https://github.com/yaml/libyaml/releases/download/0.2.5/yaml-0.2.5.tar.gz
+        sha256: c642ae9b75fee120b2d96c712538bd2cf283228d2337df2cf2988e3c02678ef4
+  # Required by libadwaita
+  - name: libsass
+    buildsystem: meson
+    sources:
+      - type: git
+        url: https://github.com/lazka/libsass.git
+        branch: meson
+        commit: 302397c0c8ae2d7ab02f45ea461c2c3d768f248e
+  # Required by libadwaita
+  - name: sassc
+    buildsystem: meson
+    sources:
+      - type: git
+        url: https://github.com/lazka/sassc.git
+        branch: meson
+        commit: 82803377c33247265d779af034eceb5949e78354
+  # Required by Hashbrown
+  - name: libadwaita
+    buildsystem: meson
+    config-opts:
+      - -Dexamples=false
+      - -Dtests=false
+    sources:
+      - type: git
+        url: https://gitlab.gnome.org/GNOME/libadwaita.git
+        tag: 1.0.0.alpha.3
+  # Hashbrown
   - name: hashbrown
     buildsystem: simple
     build-commands:
@@ -36,19 +70,18 @@ modules:
     sources:
       - type: git
         url: https://github.com/GeopJr/Hashbrown.git
-        tag: v1.3.4
-        commit: c399c2c96b94667c239c8c73446329e1a68d2123
+        branch: v2.0.0-dev # TEMP: only during this PR is a draft
         x-checker-data:
           type: git
           tag-pattern: ^v([\d.]+)$
       - type: archive
         dest: crystal/
-        url: https://github.com/crystal-lang/crystal/releases/download/1.1.1/crystal-1.1.1-1-linux-x86_64.tar.gz
-        sha256: e78873f8185b45f8c6e480a6d2a6a4f3a8b4ee7ca2594e8170dd123a41566704
+        url: https://github.com/crystal-lang/crystal/releases/download/1.2.1/crystal-1.2.1-1-linux-x86_64.tar.gz
+        sha256: 66e51bd2e72363858b5a41755396158d6aaf76b177a51741e4ab2df3323f0ff4
       - type: git
-        url: https://github.com/jhass/crystal-gobject.git
-        commit: 1e546dd592e10f0f1394ec22765c10f6e91af6e7
-        dest: lib/gobject
+        url: https://github.com/GeopJr/libadwaita.cr.git
+        commit: 672c5d7a31eb3e59439b9d2c98673d5f7b8d1314
+        dest: lib/libadwaita
       - type: git
         url: https://github.com/elorest/compiled_license.git
         tag: v1.0.0

--- a/dev.geopjr.Hashbrown.yaml
+++ b/dev.geopjr.Hashbrown.yaml
@@ -70,7 +70,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/GeopJr/Hashbrown.git
-        tag: 2.0.0
+        tag: v2.0.0
         commit: 71ad29b98c09369d07dc21b5bd664eb2e8d4b2b5
         x-checker-data:
           type: git


### PR DESCRIPTION
Hashbrown v2.0.0 brings many changes, including switching to GTK4+libadwaita.
The flatpak now builds libadwaita, as well as libyaml (required by Crystal to parse the translations during compile-time).


<details><summary>Explanation for the new permission (`--device=dri`)</summary>
<p>

```
libEGL warning: MESA-LOADER: failed to retrieve device information

libEGL warning: DRI2: could not open /dev/dri/card0 (No such file or directory)
libGL error: MESA-LOADER: failed to retrieve device information
libGL error: MESA-LOADER: failed to open amdgpu: /usr/lib/x86_64-linux-gnu/GL/default/lib/dri/amdgpu_dri.so: cannot open shared object file: No such file or directory (search paths /usr/lib/x86_64-linux-gnu/GL/default/lib/dri, suffix _dri)
libGL error: failed to load driver: amdgpu
libGL error: failed to open /dev/dri/card0: No such file or directory
libGL error: failed to load driver: radeonsi
```
While not fatal, granting that permission suppresses these errors and warnings.

</p>
</details>

Since Hashbrown v2.0.0 hasn't been released yet, the source isn't locked to a tag or a commit, that will change when it releases (until then, this PR will be a draft).